### PR TITLE
feat(heatmap): highlight edits across file; refactor into modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,17 @@ Shows the current line number (where the cursor is) in the status bar in a faint
   1. Open the repo in VS Code: `code .`
   2. Press `F5` to open a new Extension Development Host window.
 
+## Settings
+
+- `usageHeatmap.scale`: Choose how change counts map to color intensity. Options:
+  - `logarithmic` (default): Spreads low-to-moderate changes, avoids saturation on extreme hotspots.
+  - `exponential`: Emphasizes high-change hotspots; tune with `usageHeatmap.exponentialGamma`.
+  - `linear`: Uniform mapping.
+- `usageHeatmap.exponentialGamma`: Exponent when using `exponential` scale (default: 2).
+
 ## Limitations
 
-- Due to VS Code API limitations, it is not possible to change the color of the line number in the editor gutter for a single line. This extension provides a non-intrusive status bar indication instead.
+- VS Code only allows line background decorations per range; the heatmap uses subtle whole-line backgrounds and an inline info annotation for the selected line.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,29 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands": []
+    "commands": [],
+    "configuration": {
+      "title": "Usage Heatmap",
+      "properties": {
+        "usageHeatmap.scale": {
+          "type": "string",
+          "enum": [
+            "linear",
+            "logarithmic",
+            "exponential"
+          ],
+          "default": "logarithmic",
+          "markdownDescription": "Scale used to map change counts to color bins. 'logarithmic' spreads low-to-moderate changes and prevents saturation at high counts; 'exponential' emphasizes high-change hotspots; 'linear' is uniform."
+        },
+        "usageHeatmap.exponentialGamma": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 6,
+          "markdownDescription": "Exponent (gamma) when 'usageHeatmap.scale' is 'exponential'. Higher values emphasize high-change hotspots more strongly."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "pnpm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,6 +117,16 @@ export function activate(context: vscode.ExtensionContext) {
             updateDecorations(activeEditor);
         }
     }, null, context.subscriptions);
+
+    // React to configuration changes that affect scaling
+    vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('usageHeatmap.scale') || e.affectsConfiguration('usageHeatmap.exponentialGamma')) {
+            disposeAllHighlightTypes();
+            if (activeEditor) {
+                updateDecorations(activeEditor);
+            }
+        }
+    }, null, context.subscriptions);
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,14 @@
 import * as vscode from 'vscode';
-import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
 import { debounce } from './debounce';
-import * as path from 'path';
+import { createGit, getRepoContext, getHeadHash, getCountsForAllLines, blameLineMetadata } from './git';
+import { applyHeatmapHighlights, clearActiveHighlightDecorations, disposeAllHighlightTypes } from './heatmap';
 
-let decorationType: vscode.TextEditorDecorationType;
+let infoDecorationType: vscode.TextEditorDecorationType;
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Usage Heatmap extension is now active.');
 
-    decorationType = vscode.window.createTextEditorDecorationType({
+    infoDecorationType = vscode.window.createTextEditorDecorationType({
         after: {
             margin: '0 0 0 3em',
             textDecoration: 'none',
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     let activeEditor = vscode.window.activeTextEditor;
-    let git: SimpleGit | null = null;
+    
 
     const updateDecorations = async (editor: vscode.TextEditor | undefined = vscode.window.activeTextEditor) => {
         if (!editor) {
@@ -25,79 +25,59 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         // Clear existing decorations
-        editor.setDecorations(decorationType, []);
+        editor.setDecorations(infoDecorationType, []);
+        clearActiveHighlightDecorations(editor);
 
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
         if (!workspaceFolder) {
             return;
         }
 
-        const options: Partial<SimpleGitOptions> = {
-            baseDir: workspaceFolder.uri.fsPath,
-            binary: 'git',
-            maxConcurrentProcesses: 6,
-        };
-        git = simpleGit(options);
-
+        const git = createGit(workspaceFolder.uri.fsPath);
         const isRepo = await git.checkIsRepo();
         if (!isRepo) {
             return;
         }
 
         try {
-            const repoRoot = await git.revparse(['--show-toplevel']);
-            const absPath = editor.document.uri.fsPath;
-            const relPath = path.relative(repoRoot, absPath).split(path.sep).join('/');
+            const { repoRoot, relPath, lineCount } = await getRepoContext(git, editor);
 
-            const line0 = editor.selection.active.line + 1;
-
-            // ---- blame ----
-            const blameOutput = await git.raw([
-                'blame',
-                '-p',
-                '-L', `${line0},${line0}`,
-                '--',
-                relPath,
-            ]);
-
-            let author = '';
-            let date = '';
-            let summary = '';
-            const lines = blameOutput.split('\n');
-            for (const l of lines) {
-                if (l.startsWith('author ')) {
-                    author = l.replace('author ', '').trim();
-                } else if (l.startsWith('author-time ')) {
-                    const timestamp = parseInt(l.replace('author-time ', '').trim(), 10);
-                    date = new Date(timestamp * 1000).toLocaleDateString();
-                } else if (l.startsWith('summary ')) {
-                    summary = l.replace('summary ', '').trim();
-                }
+            if (lineCount <= 0) {
+                return;
             }
 
-            // ---- log history for that line ----
-            const logRangeArg = `${line0},${line0}:${relPath}`;
-            const blameLog = await git.raw([
-                'log',
-                '--no-patch',
-                '--pretty=%H',
-                '-L', logRangeArg,
-            ]);
-            const historyCount = blameLog.trim() ? blameLog.trim().split('\n').length : 0;
+            // Clamp selection line to valid range to avoid git fatal errors
+            const selectionLine = editor.selection.active.line + 1;
+            const line0 = Math.min(Math.max(1, selectionLine), lineCount);
 
-            if (author || date || summary) {
-                const decoration: vscode.DecorationOptions = {
-                    range: new vscode.Range(line0 - 1, 0, line0 - 1, 0),
-                    renderOptions: {
-                        after: {
-                            contentText: `  (Edited ${historyCount} times) ${summary}`,
-                            color: new vscode.ThemeColor('disabledForeground'),
-                            fontStyle: 'italic',
-                        },
+            // ---- compute edit counts for all lines (batched) ----
+            const headHash = await getHeadHash(git);
+            const cacheKey = `${repoRoot}::${relPath}::${headHash}`;
+            const counts = await getCountsForAllLines(git, relPath, lineCount, cacheKey);
+            const historyCount = counts[line0 - 1] ?? 0;
+
+            // Apply background highlights for all lines at once, grouped by color bin
+            applyHeatmapHighlights(editor, counts);
+
+            // ---- blame for metadata on the selected line (guarded) ----
+            const { author, date, summary } = await blameLineMetadata(git, relPath, line0);
+
+            // Apply info text (if we have anything meaningful)
+            const infoText = `  (Edited ${historyCount} times)` +
+                (summary ? ` ${summary}` : '') +
+                (author ? ` · ${author}` : '') +
+                (date ? ` · ${date}` : '');
+            const infoDecoration: vscode.DecorationOptions = {
+                range: new vscode.Range(line0 - 1, 0, line0 - 1, 0),
+                renderOptions: {
+                    after: {
+                        contentText: infoText,
+                        color: new vscode.ThemeColor('disabledForeground'),
+                        fontStyle: 'italic',
                     },
-                };
-                editor.setDecorations(decorationType, [decoration]);
-            }
+                },
+            };
+            editor.setDecorations(infoDecorationType, [infoDecoration]);
         } catch (err: any) {
             if (err && err.message) {
                 vscode.window.showErrorMessage(`Git Blame Error: ${err.message}`);
@@ -127,7 +107,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.workspace.onDidChangeTextDocument(event => {
         if (activeEditor && event.document === activeEditor.document) {
-            activeEditor.setDecorations(decorationType, []);
+            activeEditor.setDecorations(infoDecorationType, []);
+            clearActiveHighlightDecorations(activeEditor);
         }
     }, null, context.subscriptions);
 
@@ -139,12 +120,13 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-    if (decorationType) {
+    if (infoDecorationType) {
         vscode.window.visibleTextEditors.forEach(editor => {
             if (editor && editor.document) {
-                editor.setDecorations(decorationType, []);
+                editor.setDecorations(infoDecorationType, []);
             }
         });
-        decorationType.dispose();
+        infoDecorationType.dispose();
     }
+    disposeAllHighlightTypes();
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,136 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { simpleGit, SimpleGit, SimpleGitOptions } from 'simple-git';
+
+export interface RepoContext {
+  repoRoot: string;
+  absPath: string;
+  relPath: string;
+  lineCount: number;
+}
+
+export interface LineMeta {
+  author: string;
+  date: string;
+  summary: string;
+}
+
+// Cache per-file counts keyed by repo+path+HEAD
+const fileCountsCache = new Map<string, { counts: number[] }>();
+
+export function createGit(baseDir: string): SimpleGit {
+  const options: Partial<SimpleGitOptions> = {
+    baseDir,
+    binary: 'git',
+    maxConcurrentProcesses: 6,
+  };
+  return simpleGit(options);
+}
+
+export async function getRepoContext(git: SimpleGit, editor: vscode.TextEditor): Promise<RepoContext> {
+  const repoRoot = await git.revparse(['--show-toplevel']);
+  const absPath = editor.document.uri.fsPath;
+  const relPath = path.relative(repoRoot, absPath).split(path.sep).join('/');
+  const lineCount = editor.document.lineCount;
+  return { repoRoot, absPath, relPath, lineCount };
+}
+
+export async function getHeadHash(git: SimpleGit): Promise<string> {
+  try {
+    return await git.revparse(['HEAD']);
+  } catch {
+    return 'WORKTREE';
+  }
+}
+
+export async function getCountsForAllLines(
+  git: SimpleGit,
+  relPath: string,
+  lineCount: number,
+  cacheKey: string,
+): Promise<number[]> {
+  const cached = fileCountsCache.get(cacheKey);
+  if (cached && cached.counts.length === lineCount) {
+    return cached.counts;
+  }
+
+  const SAFE_MAX_LINES = 1200; // safety cap for very large files
+  const effectiveLineCount = Math.min(lineCount, SAFE_MAX_LINES);
+
+  const counts: number[] = new Array(effectiveLineCount).fill(0);
+
+  const BATCH = 6; // match maxConcurrentProcesses
+  const tasks: Array<() => Promise<void>> = [];
+  for (let i = 1; i <= effectiveLineCount; i++) {
+    const idx = i - 1;
+    tasks.push(async () => {
+      try {
+        const rangeArg = `${i},${i}:${relPath}`;
+        const out = await git.raw([
+          'log',
+          '--no-patch',
+          '--pretty=%H',
+          '-L', rangeArg,
+        ]);
+        const c = out.trim() ? out.trim().split('\n').length : 0;
+        counts[idx] = c;
+      } catch {
+        // ignore per-line failures; keep default 0
+        counts[idx] = 0;
+      }
+    });
+  }
+
+  for (let start = 0; start < tasks.length; start += BATCH) {
+    const slice = tasks.slice(start, Math.min(start + BATCH, tasks.length));
+    await Promise.all(slice.map(fn => fn()));
+  }
+
+  if (lineCount > SAFE_MAX_LINES) {
+    counts.length = lineCount;
+    for (let i = SAFE_MAX_LINES; i < lineCount; i++) counts[i] = 0;
+  }
+
+  fileCountsCache.set(cacheKey, { counts: counts.slice() });
+  return counts;
+}
+
+export async function blameLineMetadata(
+  git: SimpleGit,
+  relPath: string,
+  line0: number,
+): Promise<LineMeta> {
+  let author = '';
+  let date = '';
+  let summary = '';
+  try {
+    const blameOutput = await git.raw([
+      'blame',
+      '-p',
+      '-L', `${line0},${line0}`,
+      '--',
+      relPath,
+    ]);
+    const lines = blameOutput.split('\n');
+    for (const l of lines) {
+      if (l.startsWith('author ')) {
+        author = l.replace('author ', '').trim();
+      } else if (l.startsWith('author-time ')) {
+        const timestamp = parseInt(l.replace('author-time ', '').trim(), 10);
+        date = new Date(timestamp * 1000).toLocaleDateString();
+      } else if (l.startsWith('summary ')) {
+        summary = l.replace('summary ', '').trim();
+      }
+    }
+  } catch (blameErr: any) {
+    const msg = String(blameErr?.message || blameErr || '');
+    const benign = /has only \d+ line|no such path|exists on disk, but not in/.test(msg);
+    if (!benign) {
+      vscode.window.showErrorMessage(`Git Blame Error: ${msg}`);
+    } else {
+      console.warn('Benign blame error ignored:', msg);
+    }
+  }
+  return { author, date, summary };
+}
+


### PR DESCRIPTION
- Split logic into src/git.ts and src/heatmap.ts (SRP/DRY)
- Compute all-line edit counts with caching and batching
- Dynamic per-file normalization (min..max), blue→red mapping
- Guard blame on single-line files; clamp ranges
- Apply grouped decorations across file